### PR TITLE
fix incorrect function reference in translate.py

### DIFF
--- a/src/translate.py
+++ b/src/translate.py
@@ -109,7 +109,7 @@ def main():
                     json.dump(translated_data, f, ensure_ascii=False)
 
         # Save data - adapt according to data format
-        create_data_and_save_translate_eae(processed_src, translated_data, config)
+        create_data_and_save_eae(processed_src, translated_data, config)
     
     elif config.task == "ner":
         


### PR DESCRIPTION
translate.py calls "create_data_and_save_translate_eae" instead of "create_data_and_save_eae".